### PR TITLE
Rev to version 5.0.1 to pick up version info change for libpng16.dll

### DIFF
--- a/pango-tsc-package.autopkg
+++ b/pango-tsc-package.autopkg
@@ -3,7 +3,7 @@ nuget
    nuspec
    {
       id = pango-tsc-package;
-      version: 5.0.0;
+      version: 5.0.1.0;
       title: Pango Library;
       authors: { TechSmith Corporation, GNU };
       owners: { TechSmith Corporation };
@@ -12,8 +12,11 @@ nuget
       iconUrl: "http://www.techsmith.com/favicon.ico";
       requireLicenseAcceptance: false;
       summary: GTK Libraries 3.22.20;
-	  releaseNotes: "license issue";
-      description: @"Third party cross-platform library containing pre-built libs for pango and its dependencies of cairo, fontconfig, freetype, and other GTK libs";
+      description: @"Third party cross-platform library containing pre-built libs for pango and its dependencies of cairo, fontconfig, freetype, and other GTK libs
+         New Features:
+         Breaking Changes:
+         Bug Fixes:
+            5.0.1.0: Update dll version information for libpng16.dll so upgrades work properly";
       copyright: "";
       tags: { native, tsc, pango, cairo, fontconfig, freetype };
    };  

--- a/pango-tsc-package.autopkg
+++ b/pango-tsc-package.autopkg
@@ -1,5 +1,5 @@
-nuget
-{ 
+﻿nuget
+{
    nuspec
    {
       id = pango-tsc-package;
@@ -19,10 +19,10 @@ nuget
             5.0.1.0: Update dll version information for libpng16.dll so upgrades work properly";
       copyright: "";
       tags: { native, tsc, pango, cairo, fontconfig, freetype };
-   };  
+   };
 
    files
-   {       
+   {
       cairoInclude: { #destination = ${d_include}cairo; build\Win32\release\cairo\src\**\*.c; 
                                                         build\Win32\release\cairo\src\**\*.h; };
 
@@ -30,75 +30,76 @@ nuget
                                                         build\Win32\release\pango\pango\*.c; };
 
       freetypeInclude: { #destination = ${d_include}freetype;     build\Win32\release\freetype\include\**\*.h;};
-      freetypeSrc:     { #destination = ${d_include}freetype\src; build\Win32\release\freetype\src\**; };   
-         
+      freetypeSrc:     { #destination = ${d_include}freetype\src; build\Win32\release\freetype\src\**; };
+
       fontconfigInclude: { #destination = ${d_include}fontconfig;     build\Win32\release\fontconfig\fontconfig\** };
       fontconfigSrc:     { #destination = ${d_include}fontconfig\src; build\Win32\release\fontconfig\src\** };
 
-      glibInclude:    { #destination = ${d_include}glib;    build\Win32\release\glib\glib\**;   };    
-	  gobjectInclude: { #destination = ${d_include}gobject; build\Win32\release\glib\gobject\**;   };    
-													  
-	  Include: { #destination = ${d_include}; gtk\x64\release\include\cairo\*.h;
+      glibInclude:    { #destination = ${d_include}glib;    build\Win32\release\glib\glib\**;   };
+      gobjectInclude: { #destination = ${d_include}gobject; build\Win32\release\glib\gobject\**;   };
+
+      Include: { #destination = ${d_include}; gtk\x64\release\include\cairo\*.h;
                                               build\Win32\release\glib\glib\glib.h;
                                               build\Win32\release\glib\glib\glibconfig.h;
                                               build\Win32\release\glib\glib\glib-object.h; 
-                                              build\Win32\release\freetype\include\**\*.h;	};           
-													  
-	  [x64]
+                                              build\Win32\release\freetype\include\**\*.h;   };
+
+      [x64]
       {
-         lib:   { gtk\x64\release\lib\*.lib;		          
+         lib:   { gtk\x64\release\lib\*.lib;
                 }
-                  
+
          bin:   { gtk\x64\release\bin\*.dll;
-		          gtk\x64\release\bin\*.pdb;		          			  
-                }            
-      };   
-      [Win32]
-	  {
-	     lib:   { gtk\Win32\release\lib\cairo*.lib;
-		          gtk\Win32\release\lib\fontconfig.lib;
-				  gtk\Win32\release\lib\freetype.lib;				  
-				  gtk\Win32\release\lib\harfbuzz.lib;
-				  gtk\Win32\release\lib\gio-2.0.lib;
-		          gtk\Win32\release\lib\glib-2.0.lib;
-				  gtk\Win32\release\lib\gmodule-2.0.lib;
-				  gtk\Win32\release\lib\gobject-2.0.lib;
-				  gtk\Win32\release\lib\gthread-2.0.lib;
-				  gtk\Win32\release\lib\pixman-1.lib;
-				  gtk\Win32\release\lib\pango*.lib;	
-                  build\Win32\release\libpng-cmake\libpng16.lib;
-				  gtk\Win32\release\lib\libxml2.lib;
-				  gtk\Win32\release\lib\iconv.lib;
-				  gtk\Win32\release\lib\intl.lib;				  
-				  gtk\Win32\release\lib\zlib1.lib;				  
+                  gtk\x64\release\bin\*.pdb;
                 }
-                  
+      };
+      
+      [Win32]
+      {
+         lib:   { gtk\Win32\release\lib\cairo*.lib;
+                  gtk\Win32\release\lib\fontconfig.lib;
+                  gtk\Win32\release\lib\freetype.lib;
+                  gtk\Win32\release\lib\harfbuzz.lib;
+                  gtk\Win32\release\lib\gio-2.0.lib;
+                  gtk\Win32\release\lib\glib-2.0.lib;
+                  gtk\Win32\release\lib\gmodule-2.0.lib;
+                  gtk\Win32\release\lib\gobject-2.0.lib;
+                  gtk\Win32\release\lib\gthread-2.0.lib;
+                  gtk\Win32\release\lib\pixman-1.lib;
+                  gtk\Win32\release\lib\pango*.lib; 
+                  build\Win32\release\libpng-cmake\libpng16.lib;
+                  gtk\Win32\release\lib\libxml2.lib;
+                  gtk\Win32\release\lib\iconv.lib;
+                  gtk\Win32\release\lib\intl.lib;
+                  gtk\Win32\release\lib\zlib1.lib;
+                }
+
          bin:   { gtk\Win32\release\bin\cairo*.dll;
-		          gtk\Win32\release\bin\fontconfig.dll;				  
-				  gtk\Win32\release\bin\harfbuzz-vs14.dll;
-				  gtk\Win32\release\bin\gio-2.0.dll;
-		          gtk\Win32\release\bin\glib-2.0.dll;
-				  gtk\Win32\release\bin\gmodule-2.0.dll;
-				  gtk\Win32\release\bin\gobject-2.0.dll;
-				  gtk\Win32\release\bin\gthread-2.0.dll;
-				  gtk\Win32\release\bin\pango*.dll;
+                  gtk\Win32\release\bin\fontconfig.dll;
+                  gtk\Win32\release\bin\harfbuzz-vs14.dll;
+                  gtk\Win32\release\bin\gio-2.0.dll;
+                  gtk\Win32\release\bin\glib-2.0.dll;
+                  gtk\Win32\release\bin\gmodule-2.0.dll;
+                  gtk\Win32\release\bin\gobject-2.0.dll;
+                  gtk\Win32\release\bin\gthread-2.0.dll;
+                  gtk\Win32\release\bin\pango*.dll;
                   build\Win32\release\libpng-cmake\libpng16.dll;
-				  gtk\Win32\release\bin\libxml2.dll;
-				  gtk\Win32\release\bin\iconv.dll;
-				  gtk\Win32\release\bin\intl.dll;				  
-				  gtk\Win32\release\bin\zlib1.dll;				  
-				  
-		          gtk\Win32\release\bin\fontconfig.pdb;				  
-				  gtk\Win32\release\bin\harfbuzz-vs14.pdb;
-				  gtk\Win32\release\bin\gio-2.0.pdb;
-		          gtk\Win32\release\bin\glib-2.0.pdb;
-				  gtk\Win32\release\bin\gmodule-2.0.pdb;
-				  gtk\Win32\release\bin\gobject-2.0.pdb;
-				  gtk\Win32\release\bin\gthread-2.0.pdb;
-				  gtk\Win32\release\bin\pango*.pdb;
-                  gtk\Win32\release\bin\zlib1.pdb;				  				  
-                }            
-	  }
+                  gtk\Win32\release\bin\libxml2.dll;
+                  gtk\Win32\release\bin\iconv.dll;
+                  gtk\Win32\release\bin\intl.dll; 
+                  gtk\Win32\release\bin\zlib1.dll;
+
+                  gtk\Win32\release\bin\fontconfig.pdb;
+                  gtk\Win32\release\bin\harfbuzz-vs14.pdb;
+                  gtk\Win32\release\bin\gio-2.0.pdb;
+                  gtk\Win32\release\bin\glib-2.0.pdb;
+                  gtk\Win32\release\bin\gmodule-2.0.pdb;
+                  gtk\Win32\release\bin\gobject-2.0.pdb;
+                  gtk\Win32\release\bin\gthread-2.0.pdb;
+                  gtk\Win32\release\bin\pango*.pdb;
+                  gtk\Win32\release\bin\zlib1.pdb;
+               }
+      }
    };
 
    props
@@ -117,6 +118,6 @@ nuget
       // This node is often used to set defines that are required that must be set by
       // the consuming project in order to correctly link to the libraries in this
       // package.  Such defines may be set either globally or only set under specific
-      // conditions.	  
+      // conditions.
    }
 }


### PR DESCRIPTION
When we updated to the latest version of pango, there was a change that made it so that the libpng16.dll file no longer had version information:
![image](https://user-images.githubusercontent.com/5382895/32344919-d003ffb8-bfde-11e7-92c8-cddf98751143.png)

This is particularly problematic for Windows Installer upgrades, since it will always prefer a versioned file over a non-versioned file.

There was already a change pushed that fixes the CMakeLists so that it will use the correct version information when building the dll (see commit c78b3422b627aa0cd8f75203fe4e0187fbaaed09)

This change revs the version number so we can publish a new package with this latest change